### PR TITLE
Announcement email from info at

### DIFF
--- a/gleaning/settings.py
+++ b/gleaning/settings.py
@@ -37,6 +37,7 @@ ACCOUNT_ACTIVATION_DAYS = 7
 EMAIL_PORT = 587
 DEFAULT_FROM_EMAIL = ('The Gleaning Collective ' +
                       '<no-reply@vermontgleaningcollective.org>')
+ANNOUNCEMENT_FROM_EMAIL = 'info@vermontgleaningcollective.org'
 
 #from django.contrib.auth.models import User
 

--- a/mail_system.py
+++ b/mail_system.py
@@ -10,6 +10,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.template.base import Template as T, Context
 from django.utils.text import slugify
+from django.conf import settings
 
 from functions import primary_source
 
@@ -53,7 +54,7 @@ def mail_from_source(announcement):
 
         from_address = "{name} <{email}>".format(
             name=mo.name,
-            email="info@vermontgleaningcollective.org"
+            email=settings.ANNOUNCEMENT_FROM_EMAIL
         )
 
         if announcement.title:

--- a/mail_system.py
+++ b/mail_system.py
@@ -51,9 +51,10 @@ def mail_from_source(announcement):
         mo = announcement.member_organization
         glean = announcement.glean
 
-        from_address = slugify(
-            unicode(mo)
-        ) + "@vermontgleaningcollective.org"
+        from_address = "{name} <{email}>".format(
+            name=unicode(mo),
+            email="info@vermontgleaningcollective.org"
+        )
 
         if announcement.title:
             subject = announcement.title

--- a/mail_system.py
+++ b/mail_system.py
@@ -52,7 +52,7 @@ def mail_from_source(announcement):
         glean = announcement.glean
 
         from_address = "{name} <{email}>".format(
-            name=unicode(mo),
+            name=mo.name,
             email="info@vermontgleaningcollective.org"
         )
 


### PR DESCRIPTION
Change the announcements to always come from a consistent from address but use the member org name as the from name.
